### PR TITLE
Release 2.1.0 (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2020-06-30
+
+### Added
+
+- Changed mainnet explorer links to use Factom Realtime Explorer
+- Improved Factom node connection reliability
+- Updated dependencies
+
 ## [2.0.0] - 2020-04-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "myfactomwallet",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5843,9 +5843,9 @@
 			"dev": true
 		},
 		"eventemitter3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -7188,9 +7188,9 @@
 			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
 		},
 		"http-proxy": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
 			"requires": {
 				"eventemitter3": "^4.0.0",
 				"follow-redirects": "^1.0.0",
@@ -16819,9 +16819,9 @@
 			}
 		},
 		"websocket-extensions": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "myfactomwallet",
 	"homepage": "https://myfactomwallet.com",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"private": true,
 	"license": "MIT",
 	"dependencies": {

--- a/src/context/FactomCliController.js
+++ b/src/context/FactomCliController.js
@@ -11,6 +11,8 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import Header from '../header/Header';
 
+const FACTOM_NODE_CONNECTION_TIMEOUT = 9000;
+
 class FactomCliController extends React.Component {
 	constructor(props) {
 		super(props);
@@ -90,7 +92,7 @@ class FactomCliController extends React.Component {
 			// test connection
 			if (
 				await factomCli.factomdApi('properties', null, {
-					timeout: 2000,
+					timeout: FACTOM_NODE_CONNECTION_TIMEOUT,
 					retry: { retries: 0 },
 				})
 			) {
@@ -134,16 +136,17 @@ class FactomCliController extends React.Component {
 						</Grid>
 						<Grid item xs={12} justify="center" container>
 							<Typography variant="h5">
-								Unable to connect to Factom node. Please go to the
-								#myfactomwallet channel on{' '}
+								Unable to connect to Factom node. Try to refresh the page.
+								<br />
+								<br />
+								Support is available in the #myfactomwallet channel on{' '}
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
 									href={'https://discord.gg/79kH2pp'}
 								>
-									Discord
+									Discord.
 								</a>
-								&nbsp;for support.
 							</Typography>
 						</Grid>
 					</Grid>

--- a/src/context/NetworkController.js
+++ b/src/context/NetworkController.js
@@ -24,7 +24,8 @@ class NetworkController extends React.Component {
 			ecAbbreviationFull: 'Entry Credit',
 			apiPort: 443,
 			apiHost: 'api.factomd.net',
-			explorerURL: 'https://explorer.factoid.org',
+			explorerURL: 'https://explorer.factom.pro',
+			transactionUrlSuffix: '/transactions/',
 			pegnetApiUrl: 'https://pegapi.myfactomwallet.com/v2',
 		},
 		testnet: {
@@ -37,6 +38,7 @@ class NetworkController extends React.Component {
 			apiPort: 8288,
 			apiHost: 'api.myfactomwallet.com',
 			explorerURL: 'https://testnet.factoid.org',
+			transactionUrlSuffix: '/transaction?txid=',
 			pegnetApiUrl: '',
 		},
 	};

--- a/src/walletManager/ConvertECForm.js
+++ b/src/walletManager/ConvertECForm.js
@@ -14,12 +14,9 @@ import Grid from '@material-ui/core/Grid';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import Tooltip from '@material-ui/core/Tooltip';
 import { isValidPublicEcAddress } from 'factom/dist/factom';
 import Paper from '@material-ui/core/Paper';
 import CheckCircle from '@material-ui/icons/CheckCircleOutlined';
-
 import { ADDRESS_LENGTH } from '../constants/WALLET_CONSTANTS';
 import { toFactoids, minusBig, divideBig } from '../utils';
 import { withFactomCli } from '../context/FactomCliContext';
@@ -28,6 +25,7 @@ import { withNetwork } from '../context/NetworkContext';
 import { withSeed } from '../context/SeedContext';
 import { withWalletContext } from '../context/WalletContext';
 import AddressInfoHeader from './shared/AddressInfoHeader';
+import TransactionMessage from './shared/TransactionMessage';
 import ConvertTransactionPreview from './ConvertTransactionPreview';
 
 /**
@@ -460,30 +458,10 @@ class ConvertECForm extends Component {
 											</Typography>
 											<br />
 											<br />
-											<Typography>
-												This transaction will be visible{' '}
-												<Tooltip title="Open Factom Explorer">
-													<a
-														target="_blank"
-														rel="noopener noreferrer"
-														href={
-															networkProps.explorerURL +
-															'/transaction?txid=' +
-															values.transactionID
-														}
-													>
-														here{' '}
-														<OpenInNew
-															color="primary"
-															style={{ fontSize: 15 }}
-														/>
-													</a>
-												</Tooltip>{' '}
-												in 10-15 minutes, after being included in the next
-												Factom block currently being processed by the
-												blockchain. Funds are available for use immediately.
-												<br />
-											</Typography>
+											<TransactionMessage
+												transactionID={values.transactionID}
+											/>
+											<br />
 										</Paper>
 										<br />
 										<Button

--- a/src/walletManager/SendFactoidForm.js
+++ b/src/walletManager/SendFactoidForm.js
@@ -15,10 +15,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
 import CheckCircle from '@material-ui/icons/CheckCircleOutlined';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import Tooltip from '@material-ui/core/Tooltip';
 import { isValidPublicFctAddress } from 'factom/dist/factom';
-
 import { withFactomCli } from '../context/FactomCliContext';
 import { withWalletContext } from '../context/WalletContext';
 import { withSeed } from '../context/SeedContext';
@@ -26,6 +23,7 @@ import { withNetwork } from '../context/NetworkContext';
 import { withLedger } from '../context/LedgerContext';
 import SendTransactionPreview from './SendTransactionPreview';
 import AddressInfoHeader from './shared/AddressInfoHeader';
+import TransactionMessage from './shared/TransactionMessage';
 import { ADDRESS_LENGTH, FACTOID_REGEX } from '../constants/WALLET_CONSTANTS';
 import { toFactoshis, toFactoids, minusBig } from '../utils';
 
@@ -463,30 +461,10 @@ class SendFactoidForm extends Component {
 											</Typography>
 											<br />
 											<br />
-											<Typography>
-												This transaction will be visible{' '}
-												<Tooltip title="Open Factom Explorer">
-													<a
-														target="_blank"
-														rel="noopener noreferrer"
-														href={
-															networkProps.explorerURL +
-															'/transaction?txid=' +
-															values.transactionID
-														}
-													>
-														here{' '}
-														<OpenInNew
-															color="primary"
-															style={{ fontSize: 15 }}
-														/>
-													</a>
-												</Tooltip>{' '}
-												in 10-15 minutes, after being included in the next
-												Factom block currently being processed by the
-												blockchain. Funds are available for use immediately.
-												<br />
-											</Typography>
+											<TransactionMessage
+												transactionID={values.transactionID}
+											/>
+											<br />
 										</Paper>
 										<br />
 										<Button

--- a/src/walletManager/TransactionList.js
+++ b/src/walletManager/TransactionList.js
@@ -24,6 +24,11 @@ function TransactionList(props) {
 				<>
 					<Typography variant="h6">Recent Transactions</Typography>
 					{activeAddress_o.transactions.map(function(transaction, index) {
+						const href =
+							networkProps.explorerURL +
+							networkProps.transactionUrlSuffix +
+							transaction;
+
 						return (
 							<Typography
 								key={index}
@@ -32,15 +37,7 @@ function TransactionList(props) {
 							>
 								<b>Tx ID:</b> {transaction}{' '}
 								<Tooltip title="Open Factom Explorer">
-									<a
-										target="_blank"
-										rel="noopener noreferrer"
-										href={
-											networkProps.explorerURL +
-											'/transaction?txid=' +
-											transaction
-										}
-									>
+									<a target="_blank" rel="noopener noreferrer" href={href}>
 										<OpenInNew color="primary" style={{ fontSize: 15 }} />
 									</a>
 								</Tooltip>

--- a/src/walletManager/shared/TransactionMessage.js
+++ b/src/walletManager/shared/TransactionMessage.js
@@ -1,0 +1,50 @@
+import React, { useContext } from 'react';
+import { NetworkContext } from '../../context/NetworkContext';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+
+const TransactionMessage = ({ transactionID }) => {
+	const { networkProps } = useContext(NetworkContext);
+
+	const href =
+		networkProps.explorerURL +
+		networkProps.transactionUrlSuffix +
+		transactionID;
+
+	if (networkProps.network === 'mainnet') {
+		return <MainnetMessage href={href} />;
+	} else if (networkProps.network === 'testnet') {
+		return <TestnetMessage href={href} />;
+	}
+};
+
+const MainnetMessage = ({ href }) => (
+	<Typography>
+		The transaction status is available in the{' '}
+		<Tooltip title="Open Factom Explorer">
+			<a target="_blank" rel="noopener noreferrer" href={href}>
+				Factom Explorer.
+				<OpenInNew color="primary" style={{ fontSize: 15 }} />
+			</a>
+		</Tooltip>{' '}
+		Funds are available for use immediately.
+		<br />
+	</Typography>
+);
+
+const TestnetMessage = ({ href }) => (
+	<Typography>
+		This transaction will be visible{' '}
+		<Tooltip title="Open Factom Explorer">
+			<a target="_blank" rel="noopener noreferrer" href={href}>
+				here <OpenInNew color="primary" style={{ fontSize: 15 }} />
+			</a>
+		</Tooltip>{' '}
+		in 10-15 minutes, after being included in the next Factom block currently
+		being processed by the blockchain. Funds are available for use immediately.
+		<br />
+	</Typography>
+);
+
+export default TransactionMessage;


### PR DESCRIPTION
* Bump websocket-extensions from 0.1.3 to 0.1.4

Bumps [websocket-extensions](https://github.com/faye/websocket-extensions-node) from 0.1.3 to 0.1.4.
- [Release notes](https://github.com/faye/websocket-extensions-node/releases)
- [Changelog](https://github.com/faye/websocket-extensions-node/blob/master/CHANGELOG.md)
- [Commits](https://github.com/faye/websocket-extensions-node/compare/0.1.3...0.1.4)

Signed-off-by: dependabot[bot] <support@github.com>

* Change mainnet to use Factom Realtime Explorer

* Improve Factom node connection reliability

* Update dependencies

* Code review fixes for explorer links

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>